### PR TITLE
feat: agregar cache de productos y generacion de numero de orden

### DIFF
--- a/src/main/java/BoutiqueOnline/Controlador/HomeController.java
+++ b/src/main/java/BoutiqueOnline/Controlador/HomeController.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -178,11 +179,14 @@ public class HomeController {
      * con fecha, numero de pedido, los detalles
      */
     @GetMapping("/saveOrder")
-    public String saveOrden() {
+    public String saveOrden(Authentication authentication) {
         Date fechaCreacion = new Date();
         orden.setFechaCreacion(fechaCreacion);
         orden.setNumero(ordenService.generarNumeroOrden());
         //guardar datos del usaurio tambien
+        String email=authentication.getName();
+        
+        
         Usuario usuario = usuarioServicio.findById(4).get();
 
         orden.setUsuario(usuario);

--- a/src/main/java/BoutiqueOnline/repositorio/UsuarioRepositorio.java
+++ b/src/main/java/BoutiqueOnline/repositorio/UsuarioRepositorio.java
@@ -15,8 +15,8 @@ public interface UsuarioRepositorio extends JpaRepository<Usuario, Integer>{
 
     // Buscar usuario por correo
     Usuario findByEmail(String email);
-
-    // Este ya existe por herencia, pero puedes redefinirlo si deseas
+    
+// Este ya existe por herencia, pero puedes redefinirlo si deseas
   
     Optional<Usuario> findById(Long id);
 

--- a/src/main/java/BoutiqueOnline/servicio/OrdenServiceImp.java
+++ b/src/main/java/BoutiqueOnline/servicio/OrdenServiceImp.java
@@ -2,15 +2,19 @@ package BoutiqueOnline.servicio;
 
 import BoutiqueOnline.modelo.Orden;
 import BoutiqueOnline.repositorio.OrdenRepositorio;
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.base.Strings;
+import com.google.common.primitives.Ints;
+import com.google.common.collect.ImmutableList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class OrdenServiceImp implements OrdenService {
 
-    //declar un objeto para inyectar el objeto
     @Autowired
     private OrdenRepositorio ordenRepositorio;
 
@@ -19,41 +23,24 @@ public class OrdenServiceImp implements OrdenService {
         return ordenRepositorio.save(orden);
     }
 
-    //implementacion del metodo
     @Override
     public List<Orden> findAll() {
-        return ordenRepositorio.findAll();
+        return ImmutableList.copyOf(ordenRepositorio.findAll());
     }
 
-    //metodo para generar el numero de orden
-    public String generarNumeroOrden(){
-    int numero=0;
-    String numeroConcatenado="";
-    
-    //obtner todas las ordenes 
-    List<Orden> ordenes=findAll();
-    
-    List<Integer> numeros= new ArrayList<Integer>();
-           
-    
-    ordenes.stream().forEach(o -> numeros.add(Integer.parseInt(o.getNumero())));
-    if(ordenes.isEmpty()){
-    numero=1;
-    }else{
-    numero=numeros.stream().max(Integer::compare).get();
-    numero++;
-    }
-    //pasarlo a una cadena
-    if(numero<10){///el primero numero seria un numero
-    numeroConcatenado="000000000"+String.valueOf(numero);
-    }else if(numero>100){
-     numeroConcatenado="00000000"+String.valueOf(numero);
-    }else if(numero>1000){
-     numeroConcatenado="0000000"+String.valueOf(numero);
-    }else if(numero>10000){
-     numeroConcatenado="000000"+String.valueOf(numero);
-    }
-    
-    return numeroConcatenado;
+    @Override
+    public String generarNumeroOrden() {
+        List<Orden> ordenes = findAll();
+
+        // transforma números de orden a enteros
+        Optional<Integer> max = ordenes.stream()
+                .map(o -> Ints.tryParse(o.getNumero()))
+                .filter(n -> n != null)
+                .max(Integer::compareTo);
+
+        int nuevoNumero = max.map(n -> n + 1).orElse(1);
+
+        // usar Strings.padStart de guava
+        return Strings.padStart(String.valueOf(nuevoNumero), 10, '0');
     }
 }

--- a/src/main/java/BoutiqueOnline/servicio/ProductoServicioImple.java
+++ b/src/main/java/BoutiqueOnline/servicio/ProductoServicioImple.java
@@ -1,47 +1,65 @@
-
 package BoutiqueOnline.servicio;
 
 import BoutiqueOnline.modelo.Producto;
 import BoutiqueOnline.repositorio.ProductoRepositorio;
-import java.util.List;
-import java.util.Optional;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Service
-public class ProductoServicioImple implements ProductoServicio{
-    
+public class ProductoServicioImple implements ProductoServicio {
+
+    private final ProductoRepositorio productoRepositorio;
+
+    //caché de productos para lecturas rápidas con google.guava
+    private final Cache<Integer, Producto> productoCache = CacheBuilder.newBuilder()
+            .maximumSize(100)
+            .expireAfterWrite(10, TimeUnit.MINUTES)
+            .build();
+
     @Autowired
-    private ProductoRepositorio productoRepositorio;
+    public ProductoServicioImple(ProductoRepositorio productoRepositorio) {
+        this.productoRepositorio = productoRepositorio;
+    }
 
     @Override
     public Producto save(Producto producto) {
-        return productoRepositorio.save(producto);
+        Producto saved = productoRepositorio.save(producto);
+        productoCache.put(saved.getId(), saved); // actualizar caché al guardar
+        return saved;
     }
 
     @Override
     public Optional<Producto> get(Integer id) {
-        return productoRepositorio.findById(id);
+        Producto producto = productoCache.getIfPresent(id);
+        if (producto == null) {
+            producto = productoRepositorio.findById(id).orElse(null);
+            if (producto != null) {
+                productoCache.put(id, producto);
+            }
+        }
+        return Optional.ofNullable(producto);
     }
 
     @Override
     public void update(Producto producto) {
-       productoRepositorio.save(producto);
+        productoRepositorio.save(producto);
+        productoCache.put(producto.getId(), producto); // actualiza caché también
     }
 
     @Override
     public void delete(Integer id) {
         productoRepositorio.deleteById(id);
+        productoCache.invalidate(id); // eliminar del caché
     }
 
     @Override
     public List<Producto> findAll() {
-        return productoRepositorio.findAll();
+        return ImmutableList.copyOf(productoRepositorio.findAll());
     }
-
-    public ProductoServicioImple(ProductoRepositorio productoRepositorio) {
-        this.productoRepositorio = productoRepositorio;
-    }
-    
-    
 }

--- a/src/main/java/BoutiqueOnline/servicio/UsuarioServicio.java
+++ b/src/main/java/BoutiqueOnline/servicio/UsuarioServicio.java
@@ -13,7 +13,7 @@ public interface UsuarioServicio extends UserDetailsService{ //busqueda de un su
     
     //añadir el metodo del repositorio
     Optional<Usuario> findById(Integer id);
-   
+ 
    //metodo para guardar 
     public Usuario save(Usuario usuario);
 


### PR DESCRIPTION
- Se implementó cache en ProductoServicioImple usando Guava Cache para mejorar el rendimiento de lecturas frecuentes de productos.
- Se agregó OrdenServiceImp con método generarNumeroOrden(), que genera automáticamente un nuevo número correlativo usando Guava (Ints y Strings).
- Uso de ImmutableList en findAll() para devolver listas inmutables.
- Mejora en la organización del código de servicios y uso eficiente de recursos en memoria.
